### PR TITLE
Fixes to compile, and remove warnings

### DIFF
--- a/operations/DMxDM.c
+++ b/operations/DMxDM.c
@@ -91,7 +91,7 @@ int DMxDM(int argc, char *argv[]) {
 	}
 	
 	if(outputFileName == NULL) {
-		outputFileName = (char *) malloc(sizeof(char)*6);
+		outputFileName = (char *) malloc(sizeof(char)*7);
 		sprintf(outputFileName,"stdout");
 	}
 	

--- a/operations/DMxV.c
+++ b/operations/DMxV.c
@@ -88,7 +88,7 @@ int DMxV(int argc, char *argv[]) {
 	}
 	
 	if(outputFileName == NULL) {
-		outputFileName = (char *) malloc(sizeof(char)*6);
+		outputFileName = (char *) malloc(sizeof(char)*7);
 		sprintf(outputFileName,"stdout");
 	}
 	

--- a/operations/LUDecomposition.c
+++ b/operations/LUDecomposition.c
@@ -86,7 +86,7 @@ int LUDecomposition(int argc, char *argv[]) {
 	}
 	
 	if(outputFileName == NULL) {
-		outputFileName = (char *) malloc(sizeof(char)*6);
+		outputFileName = (char *) malloc(sizeof(char)*7);
 		sprintf(outputFileName,"stdout");
 	}
 	

--- a/solvers/ConjugateGradient.c
+++ b/solvers/ConjugateGradient.c
@@ -93,7 +93,7 @@ int ConjugateGradient(int argc, char *argv[]) {
 	}
 	
 	if(outputFileName == NULL) {
-		outputFileName = (char *) malloc(sizeof(char)*6);
+		outputFileName = (char *) malloc(sizeof(char)*7);
 		sprintf(outputFileName,"stdout");
 	}
 	

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,5 +1,5 @@
 CC=			gcc
-CFLAGS=			-g -Wall -Wno-unused-function -O2 
+CFLAGS=			-g -Wall -Wno-unused-function -O2 -std=c99
 WRAP_MALLOC=		-DUSE_MALLOC_WRAPPERS
 DFLAGS=			-DHAVE_PTHREAD $(WRAP_MALLOC)
 

--- a/utils/mmio.c
+++ b/utils/mmio.c
@@ -75,7 +75,8 @@ int mm_read_unsymmetric_sparse(const char *fname, unsigned long *M_, unsigned lo
  
     for (i=0; i<nz; i++)
     {
-        fscanf(f, "%lu %lu %lg\n", &I[i], &J[i], &val[i]);
+        if (fscanf(f, "%lu %lu %lg\n", &I[i], &J[i], &val[i]) != 3)
+		return -1;
         I[i]--;  /* adjust from 1-based to 0-based */
         J[i]--;
     }
@@ -542,13 +543,11 @@ char  *mm_typecode_to_str(MM_typecode matcode)
     char buffer[MM_MAX_LINE_LENGTH];
     char *types[4];
 	char *mm_strdup(const char *);
-    int error = 0;
+
 
     /* check for MTX type */
     if (mm_is_matrix(matcode)) 
         types[0] = MM_MTX_STR;
-    else
-        error = 1;
 
     /* check for CRD or ARR matrix */
     if (mm_is_sparse(matcode))

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -152,8 +152,8 @@ int readDenseCoordinateMatrixRowLine(char *fileName,unsigned long **I,unsigned l
 	*J = (unsigned long *)  malloc(*nz * sizeof(unsigned long));
 	*values = (double *)  malloc(*nz * sizeof(double));
 	
-	unsigned int *tmpI = *I;
-	unsigned int *tmpJ = *J;
+	unsigned long *tmpI = *I;
+	unsigned long *tmpJ = *J;
 	double *tmpValues = *values;
 	
 	//Read rows

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -17,11 +17,20 @@
   * along with Matrix Market Suite. If not, see <http://www.gnu.org/licenses/>.
   */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
+#include <unistd.h>
 
 #include "mmio.h"
 


### PR DESCRIPTION
Hello Abuin!

I wanted to try the code in my computer, but it didn't work. I think its because I have a more updated system (libc and compiler: `gcc 4.8.4 libc 2.19`).

Anyhow, I also removed the warnings. A summary of the changes (sorry for using a single commit for several things, I can split them if you want me to):
- Several mallocs only reserved 6 chars for the string "stdout".
- My compiler needs explicit `-std=c99` to compile your code, at least in `utils/`.
- I know `utils/mmio.c` is not your code, but has two problems detected by the warnings in my compiler: variable `error` not used (its asigned to 1 or 0, but nothing more), and `fscanf` value ignored (this is more important, so I added a check for the return value).
- In `utils/utils.c` you did a `int` to `long` cast, and I think I was not your intention.
- In `utils/utils.h` I had to add two definitions in order to use `timezone`, which is deprecated, and `getline`, which is an extension.

For me it works now, and no warnings.

Thank you!
